### PR TITLE
suggesting changes

### DIFF
--- a/Content.Shared/_Impstation/Replicator/ReplicatorComponent.cs
+++ b/Content.Shared/_Impstation/Replicator/ReplicatorComponent.cs
@@ -44,23 +44,17 @@ public sealed partial class ReplicatorComponent : Component
     /// </summary>
     public EntityUid? MyNest = null;
 
+    /// <summary>
+    /// actions granted when this replicator is ready to upgrade
+    /// </summary>
     [DataField]
-    public EntProtoId Level2Id = "MobReplicatorTier2";
+    public HashSet<EntProtoId> UpgradeActions = new HashSet<EntProtoId>();
 
+    /// <summary>
+    /// loc id for the message that gets displayed when a replicator is ready to upgrade. -self and -others are automatically appended to it when relevant
+    /// </summary>
     [DataField]
-    public EntProtoId Level2AltId = "MobReplicatorTier2Alt";
-
-    [DataField]
-    public EntProtoId Level3Id = "MobReplicatorTier3";
-
-    [DataField]
-    public EntProtoId Level2Action = "ActionReplicatorUpgrade2";
-
-    [DataField]
-    public EntProtoId? Level2AltAction = "ActionReplicatorUpgrade2Alt";
-
-    [DataField]
-    public EntProtoId Level3Action = "ActionReplicatorUpgrade3";
+    public LocId ReadyToUpgradeMessage = "replicator-upgrade-t1";
 
     /// <summary>
     /// The action to spawn a new nest.

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-actions.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-actions.yml
@@ -30,7 +30,7 @@
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level2.png
     event: !type:ReplicatorUpgradeActionEvent
-      targetLevel: 2
+      nextStage: MobReplicatorTier2
     useDelay: 20
 
 - type: entity
@@ -43,7 +43,7 @@
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level2alt.png
     event: !type:ReplicatorUpgradeActionEvent
-      targetLevel: 4
+      nextStage: MobReplicatorTier2Alt
     useDelay: 20
 
 - type: entity
@@ -56,5 +56,5 @@
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level3.png
     event: !type:ReplicatorUpgradeActionEvent
-      targetLevel: 3
+      nextStage: MobReplicatorTier3
     useDelay: 20

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicators.yml
@@ -112,7 +112,7 @@
       Dead:
         Base: dead
   - type: MeleeWeapon
-    soundHit: 
+    soundHit:
       path: "/Audio/Items/wirecutter.ogg"
     angle: 0
     wideAnimationRotation: 0
@@ -164,12 +164,16 @@
     prototypes:
     - StartingGearReplicatorT1Weapon
 
-# Tier 1: These guys are mooks. They're vulnerable, bad at dragging, and don't do much damage, but they have a disabler ranged attack. 
+# Tier 1: These guys are mooks. They're vulnerable, bad at dragging, and don't do much damage, but they have a disabler ranged attack.
 - type: entity
   id: MobReplicator
   parent: BaseMobReplicator
   categories: [HideSpawnMenu] # I don't want admins spawning a replicator that's unlinked to a nest
   components:
+  - type: Replicator
+    upgradeActions:
+    - ActionReplicatorUpgrade2
+    - ActionReplicatorUpgrade2Alt
   - type: CombatMode
   - type: Puller
     needsHands: false
@@ -225,7 +229,7 @@
     sounds:
       Unsexed: UnisexSilicon
 
-# Tier 2: Deconstructors. These guys are a little bit tougher, and have tools to take things apart, but they don't have the ability to enter combat mode. 
+# Tier 2: Deconstructors. These guys are a little bit tougher, and have tools to take things apart, but they don't have the ability to enter combat mode.
 - type: entity
   id: MobReplicatorTier2
   name: deconstructor
@@ -235,6 +239,9 @@
   components:
   - type: Replicator
     upgradeStage: 1
+    upgradeActions:
+    - ActionReplicatorUpgrade3
+    readyToUpgradeMessage: replicator-upgrade-t2
   - type: Puller
     needsHands: false
   - type: MovementSpeedModifier
@@ -278,7 +285,7 @@
     sounds:
       Unsexed: UnisexSilicon
 
-# Tier 2 ALT: Defender. These guys are our mid-level combatants. They have a slightly better stun laser, and a decent melee attack, but no utility functions. 
+# Tier 2 ALT: Defender. These guys are our mid-level combatants. They have a slightly better stun laser, and a decent melee attack, but no utility functions.
 - type: entity
   id: MobReplicatorTier2Alt
   name: defender
@@ -289,6 +296,9 @@
   - type: CombatMode
   - type: Replicator
     upgradeStage: 1
+    upgradeActions:
+    - ActionReplicatorUpgrade3
+    readyToUpgradeMessage: replicator-upgrade-t2
   - type: Puller
     needsHands: false
   - type: MovementSpeedModifier
@@ -332,7 +342,7 @@
     sounds:
       Unsexed: UnisexSilicon
 
-# Tier 3: These guys are tanks. Their job is to tear shit apart and kill things. They're slow, tanky, and have a weapon that does 25 blunt 30 struct. 
+# Tier 3: These guys are tanks. Their job is to tear shit apart and kill things. They're slow, tanky, and have a weapon that does 25 blunt 30 struct.
 - type: entity
   id: MobReplicatorTier3
   name: protector


### PR DESCRIPTION
doing this because suggesting larger changes like this in gh is kinda dookie; don't feel like you have to merge it or anything (and you probably shouldn't since I've not massively stress-tested it beyond "yeah it works")
anyway, this offloads all the logic around picking what upgrades a replicator can take from the system to the replicator comp by adding a list of actions to the replicator comp & having each action include the entProtoID for the replicator that it upgrades you into.
